### PR TITLE
BUILD: Some platforms install faad.h inside faad2/faad.h

### DIFF
--- a/cmake/FindFaad.cmake
+++ b/cmake/FindFaad.cmake
@@ -29,7 +29,7 @@ if(WIN32)
   find_library(FAAD_LIBRARY NAMES faad PATHS $ENV{PROGRAMFILES}/FAAD/lib DOC "The libfaad library")
 
 else(WIN32)
-  find_path(FAAD_INCLUDE_DIR faad.h DOC "The directory where faad.h resides")
+  find_path(FAAD_INCLUDE_DIR NAMES faad.h faad2/faad.h DOC "The directory where faad.h resides")
   find_library(FAAD_LIBRARY NAMES faad DOC "The libfaad library")
 
 endif(WIN32)


### PR DESCRIPTION
All systems that use pkgsrc, at least, install faad.h inside ${PREFIX}/include/faad2, so let's make sure CMake can find them.