### PR TITLE
DIST: Add Fedora-specific spec file

### DIFF
--- a/dists/fedora/build-from-git.sh
+++ b/dists/fedora/build-from-git.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This is a helper script to update the Release tag of the specfile
+# and then invoke rpmbuild --build-in-place with the correct options
+# to build from the root of the git checkout.
+
+# You need rpmbuild to build the rpm.
+
+# Thanks to StackOverflow:
+# https://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+RPM_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+XOREOS_ROOT=`git rev-parse --show-toplevel`
+SPEC_NAME=${RPM_DIR}/phaethon.spec
+
+# Compute the release snapshot, create a temporary spec. Also redine _rpmdir
+SNAPSHOT=`date +"%Y%m%d"`
+sed "s,\%global snapshot .*,\%global snapshot ${SNAPSHOT}git," < ${SPEC_NAME} > ${SPEC_NAME}.tmp
+sed "1s,^,\%define _rpmdir ${RPM_DIR}\n," -i ${SPEC_NAME}.tmp
+
+# Create a buildroot directory.
+mkdir -p ${RPM_DIR}/buildroot
+
+# Invoke rpmbuild from the root of the git repo (so --build-in-place works).
+# Also set the --buildroot and --
+cd ${XOREOS_ROOT}
+rpmbuild --build-in-place --rmspec --buildroot ${RPM_DIR}/buildroot -bb ${SPEC_NAME}.tmp
+rm -rf ${RPM_DIR}/buildroot

--- a/dists/fedora/phaethon.spec
+++ b/dists/fedora/phaethon.spec
@@ -1,0 +1,68 @@
+# If you want to build the current git checkout, run "build-from-git.sh".
+# If you want to build the last stable release of xoreos instead,
+# build from this specfile directly.
+
+# Globals, overridden by build script.
+%global snapshot 0
+
+# phaethon depends on packages in rpmfusion-free, much like xoreos.
+
+Name:           phaethon
+Version:        0.0.4
+
+# This is a bit ugly but it works.
+%if "%{snapshot}" == "0"
+Release:        1%{?dist}
+%else
+Release:        1.%{snapshot}%{?dist}
+%endif
+
+Summary:        A reimplementation of BioWare's Aurora engine (and derivatives)
+
+License:        GPLv3
+URL:            https://xoreos.org/
+# This URL is sad, because of the lack of a named release archive.
+Source0:        https://github.com/xoreos/phaethon/archive/v%{version}.tar.gz
+
+BuildRequires:  zlib-devel, libogg-devel, openal-soft-devel, libvorbis-devel
+BuildRequires:  libxml2-devel, lzma-devel, wxGTK3-devel, libtool, gettext-devel
+BuildRequires:  boost-devel, boost-system, boost-filesystem, boost-atomic,
+BuildRequires:  boost-regex, boost-locale
+
+# rpmfusion-free dependencies.
+BuildRequires:  libmad-devel
+
+%description
+Phaethon is a free/libre and open source (FLOSS) resource explorer for
+BioWare's Aurora engine games. Phaethon is part of the xoreos project;
+please see the xoreos website and its GitHub repositories for details.
+
+%prep
+%setup -q
+
+%build
+# We need to check against wx-config-3.0 for Fedora because of
+# https://bugzilla.redhat.com/show_bug.cgi?id=1077718, I think. :(
+
+./autogen.sh
+%configure WX_CONFIG=wx-config-3.0
+
+# When building in place we want to do a make clean.
+make clean
+
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+# We'll get the documentation manually.
+rm %{buildroot}%{_pkgdocdir}/*
+
+%files
+%{_bindir}/phaethon
+%doc *.md AUTHORS ChangeLog TODO
+%license COPYING*
+
+%changelog
+* Mon Feb 15 2016 Ben Rosser <rosser.bjr@gmail.com> 0.0.4-1
+- Initial package.


### PR DESCRIPTION
Include Fedora-specific spec file that can be built on any system with rpmbuild or mock installed. Also include a bash script to build RPMs "in place", i.e. from the phaethon git checkout rather than from the last stable release.

Like xoreos, this one requires rpmfusion-free packages.

There's also a minor wrinkle: due to [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=1077718) which apparently never got fixed properly (and which I have reopened), the Fedora wx-GTK3 package doesn't ship ```wx-config``` and instead ships ```wx-config-3.0```. So I patched the m4 script using sed in the spec to check for ```wx-config-3.0``` instead...

...but maybe this is something that should be in ax_check_wx.m4? My m4 isn't good enough to make the change (check for ```wx-config```, and if you fail to find it, look for ```wx-config-3.0```, and then if that's not there either, fail), however. :(